### PR TITLE
fix(subscriptions): remove reload button for customers

### DIFF
--- a/frontend/app/services/timed.js
+++ b/frontend/app/services/timed.js
@@ -62,27 +62,6 @@ export default class TimedService extends Service {
     });
   }
 
-  async getReloadPackages(billingType) {
-    const packages = await this.store.query("subscription-package", {
-      billing_type: billingType,
-    });
-
-    const REGEX_PRICE = /^Fr\./;
-
-    packages.forEach((item) => {
-      let { price } = item;
-
-      if (REGEX_PRICE.test(price)) {
-        const price_string = price.replace("Fr.", "").replace(",", "");
-        price = parseFloat(price_string);
-      }
-
-      item.set("price", price);
-    });
-
-    return packages;
-  }
-
   async placeSubscriptionOrder(project, duration, ordered) {
     const order = this.store.createRecord("subscription-order", {
       duration,

--- a/frontend/app/subscriptions/detail/controller.js
+++ b/frontend/app/subscriptions/detail/controller.js
@@ -11,10 +11,11 @@ export default class SubscriptionsDetailController extends Controller {
   @tracked project;
 
   get showReloadButton() {
-    return this.account.isInGroups("one", [
-      ENV.auth.adminRole,
-      ENV.auth.customerRole,
-    ]);
+    return this.account.isInGroups("one", [ENV.auth.adminRole]);
+  }
+
+  get showInfoBanner() {
+    return this.account.isInGroups("one", [ENV.auth.customerRole]);
   }
 
   get breadcrumbs() {

--- a/frontend/app/subscriptions/detail/template.hbs
+++ b/frontend/app/subscriptions/detail/template.hbs
@@ -19,6 +19,12 @@
         </LinkTo>
       {{/if}}
     </div>
+    {{#if this.showInfoBanner}}
+      <div uk-alert class="uk-flex uk-flex-bottom">
+        <span uk-icon="info" class="uk-margin-right"></span>
+          {{t "page.subscriptions.detail.info"}}
+      </div>
+    {{/if}}
 
   </div>
 </section>

--- a/frontend/app/subscriptions/own/controller.js
+++ b/frontend/app/subscriptions/own/controller.js
@@ -9,11 +9,4 @@ export default class SubscriptionsOwnController extends Controller {
   get projects() {
     return this.model;
   }
-
-  get showReloadLink() {
-    return this.account.isInGroups("one", [
-      ENV.auth.adminRole,
-      ENV.auth.customerRole,
-    ]);
-  }
 }

--- a/frontend/app/subscriptions/own/template.hbs
+++ b/frontend/app/subscriptions/own/template.hbs
@@ -59,12 +59,6 @@
                 <LinkTo @route="subscriptions.detail" @model={{project.id}}>
                   {{~t "page.subscriptions.own.projects.details"~}}
                 </LinkTo>
-
-                {{#if this.showReloadLink}}
-                  <LinkTo @route="subscriptions.reload" @model={{project.id}}>
-                    {{~t "page.subscriptions.own.projects.reload"~}}
-                  </LinkTo>
-                {{/if}}
               </div>
             </div>
           </li>

--- a/frontend/app/subscriptions/reload/route.js
+++ b/frontend/app/subscriptions/reload/route.js
@@ -11,13 +11,8 @@ export default class SubscriptionsReloadRoute extends Route {
   beforeModel(transition) {
     super.beforeModel(transition);
 
-    // Employees cannot recharge the subscription.
-    if (
-      !this.account.isInGroups("one", [
-        ENV.auth.adminRole,
-        ENV.auth.customerRole,
-      ])
-    ) {
+    // Employees and customers cannot recharge the subscription.
+    if (!this.account.isInGroups("one", [ENV.auth.adminRole])) {
       this.notify.error(this.intl.t("page.subscriptions.reload.no-access"));
       this.transitionTo(
         "subscriptions.detail",
@@ -29,16 +24,8 @@ export default class SubscriptionsReloadRoute extends Route {
   async model(params) {
     const project = await this.timed.getProjectDetails(params.project_id);
 
-    // Customers get a list of packages to choose from.
-    let packages = [];
-    if (this.account.isInGroup(ENV.auth.customerRole)) {
-      const billingType = project.billingType.get("id");
-      packages = await this.timed.getReloadPackages(billingType);
-    }
-
     return {
       project,
-      packages,
     };
   }
 

--- a/frontend/translations/de.yaml
+++ b/frontend/translations/de.yaml
@@ -98,6 +98,7 @@ page:
     detail:
       title: Projektdetails
       reload: Aufladen
+      info: Um Stunden zu kaufen, melden Sie sich bitte über ihren zuständigen Verkäufer.
 
       orders:
         title: Bestellungen

--- a/frontend/translations/en.yaml
+++ b/frontend/translations/en.yaml
@@ -98,6 +98,7 @@ page:
     detail:
       title: Project details
       reload: Recharge
+      info: To purchase hours, please contact us through your salesperson.
 
       orders:
         title: Past charges


### PR DESCRIPTION
Customers shouldn't be able to reload subscriptions directly.
Show an info banner for customer in project-detail.