### PR TITLE
chore: update maintainers block

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,6 @@
     "url": "https://adfinis.com/"
   },
   "maintainers": [
-    "Akanksh Saxena <akanksh.saxena@adfinis.com>",
     "Jonas Cosandey <jonas.cosandey@adfinis.com>"
   ],
   "directories": {


### PR DESCRIPTION
Dependabot errored cause of non available user for the repo.